### PR TITLE
New argument parsing

### DIFF
--- a/anime-tool
+++ b/anime-tool
@@ -13,7 +13,7 @@ my $needed_episode;
 my $other_opts;
 
 
-GetOptions(	'sub=s' => \my $subspath,
+GetOptions(	'subs=s' => \my $subspath,
 			'audio=s' => \my $audiopath);
 		  
 if (not defined $ARGV[0] or (not defined $subspath and not defined $audiopath)) {
@@ -30,23 +30,19 @@ if (not defined $ARGV[0] or (not defined $subspath and not defined $audiopath)) 
 if (defined $subspath) {
 	print "Using external subtitles\n";
 	$mode = "subs";
-	$moviepath = $ARGV[0];
-	$needed_episode = $ARGV[1];
 	#$other_opts = $ARV[4];
 } 
 if (defined $audiopath) {
 	print "Using external audio file\n";
 	$mode = "audio";
-	$moviepath = $ARGV[0];
-	$needed_episode = $ARGV[1];
 } 
 if (defined $subspath and defined $audiopath) {
 	print "Using both audio and subs\n";
 	$mode = "audiosubs";
-	$moviepath = $ARGV[0];
-	$needed_episode = $ARGV[1];
 }
 
+$moviepath = $ARGV[0];
+$needed_episode = $ARGV[1];
 
 
 # getting movie data

--- a/anime-tool
+++ b/anime-tool
@@ -2,7 +2,8 @@
 
 use Data::Dumper;
 use strict;
-
+use Getopt::Long;
+		  
 my $mode;
 
 my $moviepath;
@@ -11,7 +12,11 @@ my $audiopath;
 my $needed_episode;
 my $other_opts;
 
-if (!($ARGV[0] =~ /^-both.*/) && !($ARGV[0] =~ /^-aud.*/) && ! ($ARGV[0] =~ /^-aud.*/) && ! ($ARGV[0] =~ /^-sub.*/)) {
+
+GetOptions(	'sub=s' => \my $subspath,
+			'audio=s' => \my $audiopath);
+		  
+if (not defined $ARGV[0] or (not defined $subspath and not defined $audiopath)) {
 	print "\nThis tool searches for randomly named external files and starts mpv player\n\n";
 	print "For external audio:\n\$ anime-tool -audio '/path/to/video/folder' '/path/to/audio/folder' EPISODE_NUMBER\n\n";
 	print "For external subs:\n\$ anime-tool -subs '/path/to/video/folder' '/path/to/subs/folder' EPISODE_NUMBER\n\n";
@@ -21,28 +26,24 @@ if (!($ARGV[0] =~ /^-both.*/) && !($ARGV[0] =~ /^-aud.*/) && ! ($ARGV[0] =~ /^-a
 	exit;
 }
 
-if ($ARGV[0] =~ /^-sub.*/) {
+if (defined $subspath) {
 	print "Using external subtitles\n";
 	$mode = "subs";
-	$moviepath = $ARGV[1];
-	$subspath = $ARGV[2];
-	$needed_episode = $ARGV[3];
+	$moviepath = $ARGV[0];
+	$needed_episode = $ARGV[1];
 	#$other_opts = $ARV[4];
 } 
-if ($ARGV[0] =~ /^-aud.*/) {
+if (defined $audiopath) {
 	print "Using external audio file\n";
 	$mode = "audio";
-	$moviepath = $ARGV[1];
-	$audiopath = $ARGV[2];
-	$needed_episode = $ARGV[3];
+	$moviepath = $ARGV[0];
+	$needed_episode = $ARGV[1];
 } 
-if ($ARGV[0] =~ /^-both.*/) {
+if (defined $subspath and defined $audiopath) {
 	print "Using both audio and subs\n";
 	$mode = "audiosubs";
-	$moviepath = $ARGV[1];
-	$audiopath = $ARGV[2];
-	$subspath = $ARGV[3];
-	$needed_episode = $ARGV[4];
+	$moviepath = $ARGV[0];
+	$needed_episode = $ARGV[1];
 }
 
 

--- a/anime-tool
+++ b/anime-tool
@@ -18,11 +18,12 @@ GetOptions(	'sub=s' => \my $subspath,
 		  
 if (not defined $ARGV[0] or (not defined $subspath and not defined $audiopath)) {
 	print "\nThis tool searches for randomly named external files and starts mpv player\n\n";
-	print "For external audio:\n\$ anime-tool -audio '/path/to/video/folder' '/path/to/audio/folder' EPISODE_NUMBER\n\n";
-	print "For external subs:\n\$ anime-tool -subs '/path/to/video/folder' '/path/to/subs/folder' EPISODE_NUMBER\n\n";
-	print "For both:\n\$ anime-tool -both '/path/to/video/folder' '/path/to/audio/folder' '/path/to/subs/folder' EPISODE_NUMBER\n\n";
-	print "Example:\n\$ anime-tool -subs '~/Downloads/yoi-collection' '~/Downloads/yoi-collection/subs-rus' 69\n\n";
-	print "You need to specify episode number with leading zeroes like in original files!!!\n\n";
+	print "For external audio:\n\$ anime-tool -audio='/path/to/audio/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "For external subs:\n\$ anime-tool -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "For both:\n\$ anime-tool -audio='/path/to/audio/folder' -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "Example:\n\$ anime-tool -subs='~/Downloads/yoi-collection/subs-rus' '~/Downloads/yoi-collection' 69\n\n";
+	print "You need to specify episode number with leading zeroes like in original files!!!\n";
+	print "Notice: '--' and '-' both fine: '--audio=' or '-audio='\n\n";
 	exit;
 }
 


### PR DESCRIPTION
@POMATu 
Guess it should work better for issue #4. 

I'm not used to perl (never used it before, acutaly), but Getopt its standard module (you asked not to use CPAN) and its seems pretty clean.

I change a little the way we passed arguments:

- the path now passed after argument with an `=` sign

- you can setup audio and subs both or separetly in any order you want (after or before path to movie)

- both `-audio` or `--audio` allowed

Basically, I separete `$ARGV` and `Options`, so now it looks like:
```
anime-tool (movie) --audio="(audio)" --subs="(subs)" (episode) 
anime-tool --audio="(audio)" --subs="(subs)" (movie) (episode) 
anime-tool --audio="(audio)" (movie) --subs="(subs)" (episode) 
anime-tool (movie) (episode) --audio="(audio)" --subs="(subs)"
```
And its works with single `-` sign :
```
anime-tool (movie) -audio="(audio)" -subs="(subs)" (episode)
```

You still must pass **movie** as **first** argument and **episode number** as **second**
