### PR TITLE
New options, default movie and episode

### DIFF
--- a/anime-tool
+++ b/anime-tool
@@ -6,48 +6,58 @@ use Getopt::Long;
 		  
 my $mode;
 
-my $moviepath;
+my $moviepath = '.'; # By default its current folder
 my $subspath;
 my $audiopath;
 my $needed_episode;
 my $other_opts;
 
 
-GetOptions(	'subs=s' => \my $subspath,
-			'audio=s' => \my $audiopath);
-		  
-if (not defined $ARGV[0] or (not defined $subspath and not defined $audiopath)) {
-	print "\nThis tool searches for randomly named external files and starts mpv player\n\n";
-	print "For external audio:\n\$ anime-tool -audio='/path/to/audio/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
-	print "For external subs:\n\$ anime-tool -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
-	print "For both:\n\$ anime-tool -audio='/path/to/audio/folder' -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
-	print "Example:\n\$ anime-tool -subs='~/Downloads/yoi-collection/subs-rus' '~/Downloads/yoi-collection' 69\n\n";
-	print "You need to specify episode number with leading zeroes like in original files!!!\n";
-	print "Notice: '--' and '-' both fine: '--audio=' or '-audio=' and also shorthand: -s and -a\n\n";
-	exit;
+GetOptions(	'subs=s' => \$subspath,
+			'audio=s' => \$audiopath,
+			'episode=s' => \$needed_episode,
+			'movie=s' => \$moviepath,
+			'continue' => \my $continue,
+			'next' => \my $next,
+			'previous' => \my $previous,
+			'help' => sub {show_help()},
+) or show_help();
+	
+
+
+if ($continue or $next or $previous) {
+
+	# do loading stuff here
+	
+} else {
+	if (defined $subspath) {
+		print "Using external subtitles\n";
+		$mode = "subs";
+	} 
+	if (defined $audiopath) {
+		print "Using external audio file\n";
+		$mode = "audio";
+	} 
+	if (defined $subspath and defined $audiopath) {
+		print "Using both audio and subs\n";
+		$mode = "audiosubs";
+	}
+};
+
+# if nothing passed as argument and continue subroutine doesnt load anything
+if (not defined $subspath and not defined $audiopath) {
+	show_help()
 }
-
-if (defined $subspath) {
-	print "Using external subtitles\n";
-	$mode = "subs";
-	#$other_opts = $ARV[4];
-} 
-if (defined $audiopath) {
-	print "Using external audio file\n";
-	$mode = "audio";
-} 
-if (defined $subspath and defined $audiopath) {
-	print "Using both audio and subs\n";
-	$mode = "audiosubs";
-}
-
-$moviepath = $ARGV[0];
-$needed_episode = $ARGV[1];
-
 
 # getting movie data
 print "Finding movies numbers:";
 my %hashed_movies = insaneFindFiles(sort(grep(/.+[.](mkv|avi)$/, getDirFiles($moviepath))));
+
+# if episode is not passed then take first one in folder
+if (not defined $needed_episode) {
+	$needed_episode = (sort keys %hashed_movies)[0]
+};
+
 #print Dumper(%hashed_movies);
 my $episodename = $hashed_movies{$needed_episode};
 my $videopath = $moviepath . "/" . $episodename;
@@ -430,4 +440,15 @@ sub escape_crap {
 	# that's real crap, not a fix
 	$_[0] =~ s/[']/'"'"'/g;
 	return $_[0];
+}
+
+sub show_help {
+	print "\nThis tool searches for randomly named external files and starts mpv player\n\n";
+	print "For external audio:\n\$ anime-tool -audio='/path/to/audio/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "For external subs:\n\$ anime-tool -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "For both:\n\$ anime-tool -audio='/path/to/audio/folder' -subs='/path/to/subs/folder' '/path/to/video/folder' EPISODE_NUMBER\n\n";
+	print "Example:\n\$ anime-tool -subs='~/Downloads/yoi-collection/subs-rus' '~/Downloads/yoi-collection' 69\n\n";
+	print "You need to specify episode number with leading zeroes like in original files!!!\n";
+	print "Notice: '--' and '-' both fine: '--audio=' or '-audio=' and also shorthand: -s and -a\n\n";
+	exit;
 }


### PR DESCRIPTION
Move show help to subroutine and call it on `help` option or if something goes wrong.

Restructure code a little to make`continue`, `next` and `previous` options for #3 (still need to implement it: load last episode and check what exactly episode we need: next or previous and so on)

I guess, #6  is overhelming: basic issue was set movie folder by default as current.
Its done and we need to close it. For episode:
if no episode passed as options `-e` then take first one in finded `%movie_hash`.
(I guess we need to change it later to better solution: now its work with sort hash and [first index])