### PR TITLE
Refactor get_episode_key subrouting and mode selection

### DIFF
--- a/anime-tool
+++ b/anime-tool
@@ -433,46 +433,27 @@ return %hashed_episodes;
 }
 
 sub get_episode_key {
-	my $step = shift;
-	my $base_ep = shift;
+    my $base_ep = shift;
+    my $step = shift;
     my %hash = %{$_[0]};
     
-    my $counter = 0;
-    my $max_counter = abs $step;
-
-    if ($base_ep == -1) {
-    	foreach my $num (sort keys %hash) {
-    		return $num;
-    	}
+    # get index of of base episode
+    my @sorted_episodes = sort keys %hash;
+    my ($index) = grep { $sorted_episodes[$_] eq $base_ep } 0 .. $#sorted_episodes;
+    $index = 0 if not defined $index;
+    
+    # return first episode number if oute of range
+    if ($index + $step <= 0) {
+        return $sorted_episodes[0];
     }
 
-    if ($step>=0) {
-		foreach my $num (sort keys %hash) {
+    # return last episode number if out of range
+    if ($index + $step >= $#sorted_episodes) {
+        return $sorted_episodes[$#sorted_episodes];
+    }
 
-			if ($counter > 0) {
-				$counter++;
-			}
-			if ($num eq $base_ep) {
-				$counter++;
-			}
-			if ($counter>$max_counter) {
-				return $num;
-			}
-		}
-	} else {
-		foreach my $num (reverse sort keys %hash) {
-
-			if ($counter > 0) {
-				$counter++;
-			}
-			if ($num eq $base_ep) {
-				$counter++;
-			}
-			if ($counter>$max_counter) {
-				return $num;
-			}
-		}
-	}
+    # return episode + (-) step
+    return $sorted_episodes[$index + $step]
 }
 
 sub escape_crap {

--- a/anime-tool
+++ b/anime-tool
@@ -4,7 +4,7 @@ use Data::Dumper;
 use strict;
 use Getopt::Long;
 		  
-my $mode;
+my $mode = '';
 
 my $moviepath = '.'; # By default its current folder
 my $subspath;
@@ -32,15 +32,11 @@ if ($continue or $next or $previous) {
 } else {
 	if (defined $subspath) {
 		print "Using external subtitles\n";
-		$mode = "subs";
+		$mode = $mode."subs";
 	} 
 	if (defined $audiopath) {
 		print "Using external audio file\n";
-		$mode = "audio";
-	} 
-	if (defined $subspath and defined $audiopath) {
-		print "Using both audio and subs\n";
-		$mode = "audiosubs";
+		$mode = $mode."audio";
 	}
 };
 


### PR DESCRIPTION
Test data:
```
my %anime = (
	'09' => 'Wangan Midnight - 09 [DVDRip 1280x720 x264 AC3]',
	'08' => 'Wangan Midnight - 08 [DVDRip 1280x720 x264 AC3]',
	'06' => 'Wangan Midnight - 06 [DVDRip 1280x720 x264 AC3]',
	'07' => 'Wangan Midnight - 07 [DVDRip 1280x720 x264 AC3]',
	'11' => 'Wangan Midnight - 11 [DVDRip 1280x720 x264 AC3]',
	'10' => 'Wangan Midnight - 10 [DVDRip 1280x720 x264 AC3]'
);
```

Most important: I changed arguments order in get_episode_key subroutine, because its seems more reasonable for me and improve readability:

Now arguments have order:
`$base_ep`, `$step`, `ref to %hash`

And when you call it you say: get episode `'07'` and step `+2` from it in this `\%anime` hash.
```
get_episode_key('07', +2, \%anime);
```

**Also**, it now return first episode if base is incorrent and if requested number is out of range

```
get_episode_key('06', -1 , \%anime);
returns: 06

get_episode_key(0, 0 , \%anime);
returns: 06

get_episode_key('10', -200 , \%anime);
returns: 06
```

Same for the top limit
```
get_episode_key('06', +200 , \%anime);
returns: 11

get_episode_key(0, +200 , \%anime);
returns: 11
```

Zero `0` as first argument in this example (as any other incorrect output) means get `first episode` and step `+200` on it in. It may be not so useful, but we have this option.



About **mode selection**:
I remove unneeded part when we check if both variables are set, because in the next part you use regular expression with `include` option, so order doesn't matter.
I'm just concatinate `subs` and `audio` for this `$mode` variable (make it blank by default)