### PR TITLE
Return 'undef' from get_episode_key if out of range. Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,22 @@ And yeah it will figure out all shit even in this case! And link each episode to
 
 # Usage
 
-Either will work. You can specify audio, subs or both as argument.
+Either will work. You can specify audio, subs or both as argument. Order doesn't matter. `=` sign is not required.
+You can also use shorthand arguments for bash autocompletion.
+Movie (default current directory) and episode (default first found) are optional, but either audio or subtitles are required.
+```
+anime-tool --movie="(movie)" --audio="(audio)" --subs="(subs)" --episode="(episode)"
+anime-tool -movie="(movie)" -audio="(audio)" -subs="(subs)" -episode="(episode)"
+anime-tool -m="(movie)" -a="(audio)" -s="(subs)" -e="(episode)"
+anime-tool -m (movie) -a (audio) -s (subs) -e (episode)
 
-```
-anime-tool (movie) --audio="(audio)" --subs="(subs)" (episode) 
-anime-tool --audio="(audio)" --subs="(subs)" (movie) (episode) 
-anime-tool --audio="(audio)" (movie) --subs="(subs)" (episode) 
-anime-tool (movie) (episode) --audio="(audio)" --subs="(subs)"
-```
-
-You can also use shorthand arguments for bash autocompletion
-```
-anime-tool (movie) -a "(audio)" -s "(subs)" (episode) 
+anime-tool -a (audio) -s (subs)
 ```
 
 Example
 ```
 cd /downloads/anime
-anime-tool . 01 -a ./RUS_sound -s ./subs\ rus
+anime-tool -a ./RUS_sound -s ./subs\ rus -e 01
 ```
 
 # Warning

--- a/anime-tool
+++ b/anime-tool
@@ -51,7 +51,7 @@ my %hashed_movies = insaneFindFiles(sort(grep(/.+[.](mkv|avi)$/, getDirFiles($mo
 
 # if episode is not passed then take first one in folder
 if (not defined $needed_episode) {
-	$needed_episode = (sort keys %hashed_movies)[0]
+	$needed_episode = get_episode_key(0,0,\%hashed_movies);
 };
 
 #print Dumper(%hashed_movies);

--- a/anime-tool
+++ b/anime-tool
@@ -442,14 +442,10 @@ sub get_episode_key {
     my ($index) = grep { $sorted_episodes[$_] eq $base_ep } 0 .. $#sorted_episodes;
     $index = 0 if not defined $index;
     
-    # return first episode number if oute of range
-    if ($index + $step <= 0) {
-        return $sorted_episodes[0];
-    }
-
-    # return last episode number if out of range
-    if ($index + $step >= $#sorted_episodes) {
-        return $sorted_episodes[$#sorted_episodes];
+    # return undef if number out of range
+    if ($index + $step < 0 or
+        $index + $step > $#sorted_episodes) {
+        return undef
     }
 
     # return episode + (-) step


### PR DESCRIPTION
`get_episode_key` return `undef` if there is no previous or next episode (out of range).

In future, we can check
```
my $next_episode = get_episode_key($needed_episode, +1, \%hashed_movies);
watch($next_episode) if defined $next_episode;
```